### PR TITLE
Add legacy files elm-package.json and elm.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Elm plugin for asdf version manager
 <hr />
 
 [![Main workflow](https://github.com/asdf-community/asdf-elm/workflows/Main%20workflow/badge.svg)](https://github.com/asdf-community/asdf-elm/actions)
-[![Average time to resolve an issue](https://isitmaintained.com/badge/resolution/asdf-community/asdf-elm.svg)](https://isitmaintained.com/project/asdf-community/asdf-elm "Average time to resolve an issue")
-[![Percentage of issues still open](https://isitmaintained.com/badge/open/asdf-community/asdf-elm.svg)](https://isitmaintained.com/project/asdf-community/asdf-elm "Percentage of issues still open")
+[![Average time to resolve an issue](https://isitmaintained.com/badge/resolution/asdf-community/asdf-elm.svg)](https://isitmaintained.com/project/asdf-community/asdf-elm 'Average time to resolve an issue')
+[![Percentage of issues still open](https://isitmaintained.com/badge/open/asdf-community/asdf-elm.svg)](https://isitmaintained.com/project/asdf-community/asdf-elm 'Percentage of issues still open')
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](http://makeapullrequest.com)
 [![License](https://img.shields.io/github/license/asdf-community/asdf-elm?color=brightgreen)](https://github.com/asdf-community/asdf-elm/blob/master/LICENSE)
 
@@ -29,3 +29,14 @@ asdf plugin-add elm https://github.com/asdf-community/asdf-elm.git
 
 Check [asdf](https://github.com/asdf-vm/asdf) readme for instructions on how to
 install & manage versions.
+
+## Useful information
+
+asdf uses the `.tool-versions` for auto-switching between software versions. To
+ease migration, you can have it read `elm.json` or `elm-package.json` file to
+find out what version of Elm should be used. This only works with the exact
+version. To do this, add the following to `~/.asdfrc`:
+
+```
+legacy_version_file = yes
+```

--- a/bin/list-legacy-filenames
+++ b/bin/list-legacy-filenames
@@ -1,3 +1,20 @@
 #!/usr/bin/env bash
+#
+# Copyright 2019 asdf-elm authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -eo pipefail
 
 echo "elm-package.json elm.json"

--- a/bin/list-legacy-filenames
+++ b/bin/list-legacy-filenames
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo "elm-package.json elm.json"

--- a/bin/parse-legacy-file
+++ b/bin/parse-legacy-file
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+echo $(
+  cat $1 | grep -oiE '"elm-version": "([0-9\.]+)"' | grep -oE '[0-9\.]+'
+)

--- a/bin/parse-legacy-file
+++ b/bin/parse-legacy-file
@@ -1,5 +1,22 @@
 #!/usr/bin/env bash
+#
+# Copyright 2019 asdf-elm authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
-echo $(
-  cat $1 | grep -oiE '"elm-version": "([0-9\.]+)"' | grep -oE '[0-9\.]+'
-)
+set -eo pipefail
+
+version=$(grep -oiE '"elm-version": "([0-9\.]+)"' <"$1" | grep -oE '[0-9\.]+')
+
+echo "$version"


### PR DESCRIPTION
Some projects have a fixed elm version for those we can parse the
elm-package.json or elm.json and extract the version. Files with a
version range, e.g. '0.18.0 <= v < 0.19.0', are left alone.