### PR TITLE
Fix list-all to get tags for elm/compiler using git ls-remote

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -33,4 +33,12 @@ github_releases() {
 
 versions="$(github_releases)"
 
-echo "$versions"
+#echo "$versions"
+
+readonly GH_REPO="github.com/elm/compiler"
+list_github_tags() {
+  git ls-remote --tags --refs "https://$GH_REPO" |
+    grep -o 'refs/tags/.*' | cut -d/ -f3- |
+    sed 's/^v//' # NOTE: You might want to adapt this sed to remove non-version strings from tags
+}
+echo "$(list_github_tags | sort_versions | tr '\n' ' ')"


### PR DESCRIPTION
list_versions() failed to get tag names from result of curl to github api for releases, because api returns single-line json. grep/sed are unable to work with this.

Using git ls-remote instead to get the tags.