### PR TITLE
README: include asdf >= v0.16.0 command

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@
 ## Installation
 
 ```bash
+# asdf v0.16.0 and above
+asdf plugin add elm https://github.com/asdf-community/asdf-elm.git
+
+# asdf v0.15.x and below
 asdf plugin-add elm https://github.com/asdf-community/asdf-elm.git
 ```
 


### PR DESCRIPTION
## Context

Since asdf `v0.16.0` and above, [hyphenated commands have been removed](https://asdf-vm.com/guide/upgrading-to-v0-16.html#breaking-changes).

## Approach

This PR updates the README instruction to include the non-hyphenated command on top of the hyphenated command in order to make it compatible for readers to choose the right command to copy.